### PR TITLE
Add OSU GPU pt2pt bandwidth test with MPI4Py and CuPy

### DIFF
--- a/checks/apps/python/check_mpi4py.py
+++ b/checks/apps/python/check_mpi4py.py
@@ -29,7 +29,7 @@ class osu_gpu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
 
 
 @rfm.simple_test
-class osu_gpu_pt2pt_bw_single_node_test(osu_gpu_pt2pt_bw_base):
+class osu_gpu_pt2pt_bw_two_nodes_test(osu_gpu_pt2pt_bw_base):
     num_tasks_per_node = 1
     num_gpus_per_node = 1
     reference = {
@@ -38,7 +38,7 @@ class osu_gpu_pt2pt_bw_single_node_test(osu_gpu_pt2pt_bw_base):
 
 
 @rfm.simple_test
-class osu_gpu_pt2pt_bw_two_nodes_test(osu_gpu_pt2pt_bw_base):
+class osu_gpu_pt2pt_bw_single_node_test(osu_gpu_pt2pt_bw_base):
     num_tasks_per_node = 2
     num_gpus_per_node = 2
     reference = {

--- a/checks/apps/python/check_mpi4py.py
+++ b/checks/apps/python/check_mpi4py.py
@@ -9,11 +9,12 @@ class osu_gpu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
     descr = 'OSU GPU to GPU bandwith test with mpi4py and cupy'
     valid_systems = ['lumi:gpu']
     valid_prog_environs = ['builtin']
-    modules = ['rocm', 'CuPy', 'MPI4Py']
+    modules = ['rocm', 'CuPy']
     num_tasks = 2
     executable = './select_gpu.sh python osu_bw_cupy.py'
     variables = {
-        'MPICH_GPU_SUPPORT_ENABLED': '1'
+        'MPICH_GPU_SUPPORT_ENABLED': '1',
+        'LD_PRELOAD': '${CRAY_MPICH_ROOTDIR}/gtl/lib/libmpi_gtl_hsa.so'
     }
 
     @sanity_function

--- a/checks/apps/python/check_mpi4py.py
+++ b/checks/apps/python/check_mpi4py.py
@@ -1,0 +1,46 @@
+import os
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+class osu_gpu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
+    # This check was adapted to GPUs from mpi4py's script
+    # https://github.com/mpi4py/mpi4py/blob/master/demo/osu_bw.py
+    descr = 'OSU GPU to GPU bandwith test with mpi4py and cupy'
+    valid_systems = ['lumi:gpu']
+    valid_prog_environs = ['builtin']
+    modules = ['rocm/5.1.4', 'cray-python']
+    num_tasks = 2
+    executable = 'python'
+    executable_opts = ['osu_bw_cupy.py']
+    variables = {
+        'MPICH_GPU_SUPPORT_ENABLED': '1'
+    }
+
+    @sanity_function
+    def assert_found_max_bandwidth(self):
+        max_bandwidth = r'4194304'
+        return sn.assert_found(max_bandwidth, self.stdout)
+
+    @performance_function('MB/s')
+    def bandwidth(self):
+        return sn.extractsingle(r'4194304\s+(?P<bw>\S+)',
+                                self.stdout, 'bw', float)
+
+
+@rfm.simple_test
+class osu_gpu_pt2pt_bw_single_node_test(osu_gpu_pt2pt_bw_base):
+    num_tasks_per_node = 1
+    num_gpus_per_node = 1
+    reference = {
+        'lumi:gpu': {'bandwidth': (23952.10, -0.05, None, 'MB/s')}
+    }
+
+
+@rfm.simple_test
+class osu_gpu_pt2pt_bw_two_nodes_test(osu_gpu_pt2pt_bw_base):
+    num_tasks_per_node = 2
+    num_gpus_per_node = 2
+    reference = {
+        'lumi:gpu': {'bandwidth': (45723.99, -0.05, None, 'MB/s')}
+    }

--- a/checks/apps/python/check_mpi4py.py
+++ b/checks/apps/python/check_mpi4py.py
@@ -9,10 +9,9 @@ class osu_gpu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
     descr = 'OSU GPU to GPU bandwith test with mpi4py and cupy'
     valid_systems = ['lumi:gpu']
     valid_prog_environs = ['builtin']
-    modules = ['rocm/5.1.4', 'cray-python']
+    modules = ['rocm', 'CuPy', 'MPI4Py']
     num_tasks = 2
-    executable = 'python'
-    executable_opts = ['osu_bw_cupy.py']
+    executable = './select_gpu.sh python osu_bw_cupy.py'
     variables = {
         'MPICH_GPU_SUPPORT_ENABLED': '1'
     }
@@ -42,5 +41,5 @@ class osu_gpu_pt2pt_bw_single_node_test(osu_gpu_pt2pt_bw_base):
     num_tasks_per_node = 2
     num_gpus_per_node = 2
     reference = {
-        'lumi:gpu': {'bandwidth': (45723.99, -0.05, None, 'MB/s')}
+        'lumi:gpu': {'bandwidth': (125288.14, -0.05, None, 'MB/s')}
     }

--- a/checks/apps/python/src/osu_bw_cupy.py
+++ b/checks/apps/python/src/osu_bw_cupy.py
@@ -30,11 +30,9 @@ def osu_bw(
             errmsg = None
         raise SystemExit(errmsg)
 
-    device_id = int(os.environ['SLURM_LOCALID'])
-    with cp.cuda.Device(device_id):
-        s_buf = cp.arange(MAX_MSG_SIZE, dtype='i')
-        r_buf = cp.empty_like(s_buf)
-        cp.cuda.get_current_stream().synchronize()
+    s_buf = cp.arange(MAX_MSG_SIZE, dtype='i')
+    r_buf = cp.empty_like(s_buf)
+    cp.cuda.get_current_stream().synchronize()
 
     if myid == 0:
         print('# %s' % (BENCHMARH,))

--- a/checks/apps/python/src/osu_bw_cupy.py
+++ b/checks/apps/python/src/osu_bw_cupy.py
@@ -1,0 +1,88 @@
+# Adapted from https://github.com/mpi4py/mpi4py/blob/master/demo/osu_bw.py
+# and https://mpi4py.readthedocs.io/en/stable/tutorial.html#cuda-aware-mpi-python-gpu-arrays  # noqa: E501
+# http://mvapich.cse.ohio-state.edu/benchmarks/
+
+import os
+import cupy as cp
+from mpi4py import MPI
+
+
+def osu_bw(
+    BENCHMARH="MPI G2G Bandwidth Test",
+    skip=10,
+    loop=100,
+    window_size=64,
+    skip_large=2,
+    loop_large=20,
+    window_size_large=64,
+    large_message_size=8192,
+    MAX_MSG_SIZE=1 << 22,
+):
+
+    comm = MPI.COMM_WORLD
+    myid = comm.Get_rank()
+    numprocs = comm.Get_size()
+
+    if numprocs != 2:
+        if myid == 0:
+            errmsg = "This test requires exactly two processes"
+        else:
+            errmsg = None
+        raise SystemExit(errmsg)
+
+    device_id = int(os.environ['SLURM_LOCALID'])
+    with cp.cuda.Device(device_id):
+        s_buf = cp.arange(MAX_MSG_SIZE, dtype='i')
+        r_buf = cp.empty_like(s_buf)
+        cp.cuda.get_current_stream().synchronize()
+
+    if myid == 0:
+        print('# %s' % (BENCHMARH,))
+    if myid == 0:
+        print('# %-8s%20s' % ("Size [B]", "Bandwidth [MB/s]"))
+
+    message_sizes = [2**i for i in range(30)]
+    for size in message_sizes:
+        if size > MAX_MSG_SIZE:
+            break
+        if size > large_message_size:
+            skip = skip_large
+            loop = loop_large
+            window_size = window_size_large
+
+        iterations = list(range(loop+skip))
+        window_sizes = list(range(window_size))
+        requests = [MPI.REQUEST_NULL] * window_size
+        #
+        comm.Barrier()
+        if myid == 0:
+            s_msg = [s_buf, size, MPI.BYTE]
+            r_msg = [r_buf,    4, MPI.BYTE]
+            for i in iterations:
+                if i == skip:
+                    t_start = MPI.Wtime()
+                for j in window_sizes:
+                    requests[j] = comm.Isend(s_msg, 1, 100)
+                MPI.Request.Waitall(requests)
+                comm.Recv(r_msg, 1, 101)
+
+            t_end = MPI.Wtime()
+        elif myid == 1:
+            s_msg = [s_buf,    4, MPI.BYTE]
+            r_msg = [r_buf, size, MPI.BYTE]
+            for i in iterations:
+                for j in window_sizes:
+                    requests[j] = comm.Irecv(r_msg, 0, 100)
+                MPI.Request.Waitall(requests)
+                comm.Send(s_msg, 0, 101)
+        #
+        if myid == 0:
+            MB = size / 1e6 * loop * window_size
+            s = t_end - t_start
+            print('%-10d%20.2f' % (size, MB/s))
+
+    cp.allclose(s_buf, r_buf)
+
+
+if __name__ == '__main__':
+    osu_bw()

--- a/checks/apps/python/src/select_gpu.sh
+++ b/checks/apps/python/src/select_gpu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export LOCAL_RANK=$SLURM_LOCALID
+export ROCR_VISIBLE_DEVICES=$SLURM_LOCALID
+exec $*


### PR DESCRIPTION
To try this, cupy and mpi4py can be installed using https://github.com/Lumi-supercomputer/LUMI-EasyBuild-contrib/pull/40 and https://github.com/Lumi-supercomputer/LUMI-EasyBuild-contrib/pull/41.

Otherwise:
```bash
module load LUMI/22.08  partition/G
module load rocm
module load cray-python

export ROCM_HOME=$CRAY_ROCM_DIR
export CUPY_INSTALL_USE_HIP=1
export HCC_AMDGPU_TARGET=gfx90a

pip install cupy
```
and
```bash
module load LUMI/22.08  partition/G
module load rocm
module load cray-python

LDFLAGS='-L/${CRAY_ROCM_DIR}/lib64 -lamdhip64' MPICC=cc pip install mpi4py
```