### PR TITLE
Slurm affinity checks with hybrid_check and check_gpu

### DIFF
--- a/checks/slurm/affinity_check.py
+++ b/checks/slurm/affinity_check.py
@@ -1,0 +1,77 @@
+import os
+import json
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+import reframe.utility.osext as osext
+from reframe.core.exceptions import SanityError
+
+
+class AffinityTestBase(rfm.RunOnlyRegressionTest):
+    '''Base class for the affinity checks.'''
+
+    # Variables to control the hint and binding options on the launcher.
+    multithread = parameter([True, False])
+    valid_systems = ['lumi:gpu']
+    valid_prog_environs = ['PrgEnv-gnu']
+    maintainers = ['mszpindler']
+    tags = {'production'}
+
+
+class AffinityOpenMPBase(AffinityTestBase):
+    '''Extend affinity base with OMP hooks.
+
+    The tests derived from this class book the full node and place the
+    threads acordingly based exclusively on the OMP_BIND env var. The
+    number of total OMP_THREADS will vary depending on what are we
+    binding the OMP threads to (e.g. if we bind to sockets, we'll have as
+    many threads as sockets).
+    '''
+
+    omp_bind = variable(str)
+    omp_proc_bind = variable(str, value='close')
+    num_tasks = 1
+
+    @run_before('run')
+    def set_num_cpus_per_task(self):
+        self.job.launcher.options = ['--cpus-per-task=$SLURM_CPUS_ON_NODE']
+
+    @run_before('run')
+    def set_omp_vars(self):
+        self.variables = {
+            'OMP_PLACES': self.omp_bind,
+            'OMP_PROC_BIND': self.omp_proc_bind,
+        }
+
+@rfm.simple_test
+class HybridCheck(AffinityOpenMPBase):
+
+    exclusive_access= True
+    omp_bind = 'cores'
+    modules = ['lumi-CPEtools']
+
+    @run_after('init')
+    def set_executable(self):
+        self.executable = 'hybrid_check'
+        self.executable_opts = ['-r']
+
+    @run_after('init')
+    def set_threading(self):
+        if self.multithread:
+            self.use_multithreading = True
+            self.variables['OMP_PLACES'] = 'threads' 
+        else:
+            self.use_multithreading = False
+            self.variables['OMP_PLACES'] = 'cores' 
+ 
+
+    @run_before('run')
+    def set_omp_vars(self):
+        self.variables['OMP_PROC_BIND'] = 'close'
+            #'OMP_PLACES': 'cores',
+            #'OMP_PROC_BIND': 'close',
+
+    @sanity_function
+    def check_thread_pin(self):
+        nthreads = sn.extractsingle(r'Running\s+(\S+)\s+threads\s+.*',self.stdout, 1, int)  
+        return sn.assert_eq(nthreads, sn.count(sn.findall(r'hybrid_check', self.stdout)))

--- a/checks/slurm/affinity_check.py
+++ b/checks/slurm/affinity_check.py
@@ -12,7 +12,7 @@ class AffinityTaskBase(rfm.RunOnlyRegressionTest):
 
     # Variables to control the hint and binding options on the launcher.
     multithread = parameter([True, False])
-    valid_systems = ['lumi:gpu']
+    valid_systems = ['lumi:gpu', 'lumi:small']
     valid_prog_environs = ['PrgEnv-gnu']
     maintainers = ['mszpindler']
     tags = {'production'}
@@ -38,7 +38,9 @@ class AffinityTaskBase(rfm.RunOnlyRegressionTest):
             self.variables['OMP_PLACES'] = 'cores' 
 
 @rfm.simple_test
-class SingleTask(AffinityTaskBase):
+class SingleTask_Check(AffinityTaskBase):
+
+    # Tests single MPI task pins threads to unique CPUs
 
     num_tasks = 1
 
@@ -46,34 +48,134 @@ class SingleTask(AffinityTaskBase):
     def set_num_cpus_per_task(self):
         self.job.launcher.options = ['--cpus-per-task=$SLURM_CPUS_ON_NODE']
 
- 
     @sanity_function
     def check_thread_pin(self):
         nthreads = sn.extractsingle(r'Running\s+(\S+)\s+threads\s+.*',self.stdout, 1, int)  
-        return sn.assert_eq(nthreads, sn.count(sn.findall(r'hybrid_check', self.stdout)))
+        thread_mask = sn.extractall(r'mask\s+(?P<mask>\S+)', self.stdout, 'mask', int)
+        return sn.assert_eq(nthreads, sn.count_uniq(thread_mask))
 
 @rfm.simple_test
-class TaskPerGPU(AffinityTaskBase):
+class HybridTask_Check(AffinityTaskBase):
+
+    # Tests hybrid MPI job pins task's threads to the same NUMA domain
+
+    dom_size = 16
+
+    @run_before('run')
+    def set_task_and_threads(self):
+        if self.current_partition.name in ['gpu']:
+            self.num_tasks = 8
+            self.num_threads = 7 
+        elif self.current_partition.name in ['small']:
+            self.num_tasks = 16
+            self.num_threads = 8 
+
+    @run_before('run')
+    def set_num_cpus_per_task(self):
+        if self.current_partition.name in ['gpu']:
+            cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
+            self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+        elif self.current_partition.name in ['small']:
+            self.job.launcher.options = [f'--cpus-per-task={self.num_threads}']
+
+    @sanity_function
+    def check_thread_pin(self):
+        for rank in range(self.num_tasks):
+           thread_mask = sn.extractall(rf'MPI rank\s+{rank}\/\S+\s+OpenMP thread\s+\S+\/\S+\s+on cpu\s+\S+\/\S+\s+of\s+\S+\s+mask\s+(?P<mask>\S+)', self.stdout, 'mask', int)
+           thread_dom = [mask // self.dom_size for mask in thread_mask]
+           if not(len(thread_dom) == self.num_threads and thread_dom.count(thread_dom[0]) == len(thread_dom)):
+               return False
+        return True
+
+@rfm.simple_test
+class GPUPerTask_Check(AffinityTaskBase):
+
+    # Tests for Slum CPU binding with one GPU per MPI task (without manual GPU selection) 
+    # GPU-centric NUMA ordering
+    # https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/lumig-job/#mpi-based-job
+
+    num_gpus = 8
+    num_gpus_per_node = num_gpus 
+    num_tasks = num_gpus
+
+    @run_after('init')
+    def set_executable(self):
+        self.executable = 'gpu_check'
+        self.executable_opts = ['-l']
+
+    @run_before('run')
+    def set_num_gpus_per_task(self):
+        self.job.options = [f'--gpus-per-task=1']
+
+    @run_before('run')
+    def set_cpu_map(self):
+        self.job.launcher.options = ['--cpu-bind="map_cpu:48,56,16,24,1,8,32,40"']
+
+    @sanity_function
+    def check_cpu_gpu_numa_bind(self):
+        cpu_bind = sn.extractall(r'\(CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+
+        gpu_bind = sn.extractall(r'\(GCD\S+\/CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+        return sn.assert_eq(cpu_bind, gpu_bind)
+
+@rfm.simple_test
+class Hybrid_GPUSelect_Check(AffinityTaskBase):
+
+    # Tests for Slurm CPU binding with a custom mask and GPU manual per task selection 
+    # GPU-centric NUMA ordering
+    # https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/lumig-job/#hybrid-mpiopenmp-job
 
     num_gpus = 8
     num_gpus_per_node = num_gpus 
     num_tasks = num_gpus
     num_threads = num_tasks - 1
 
-    @run_before('run')
-    def set_num_cpus_per_task(self):
-        self.job.launcher.options = [f'--cpus-per-task={self.num_threads}']
-
-    @sanity_function
-    def check_thread_pin(self):
-        nranks = sn.extractsingle(r'Running\s+(\S+)\s+MPI\s+ranks\s+.*',self.stdout, 1, int)  
-        nthreads = sn.extractsingle(r'Running\s+\S+\s+MPI\s+ranks\s+with\s+(\S+)\s+.*',self.stdout, 1, int)
-        return sn.assert_eq(nranks, self.num_tasks) 
-
-@rfm.simple_test
-class TaskPerGPU_CPUMap(TaskPerGPU):
+    @run_after('init')
+    def set_executable(self):
+        self.executable = 'gpu_check'
+        self.executable_opts = ['-l']
 
     @run_before('run')
     def set_cpu_mask(self):
         cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
         self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+
+    @run_before('run')
+    def select_gpu(self):
+        self.prerun_cmds = ['cat << EOF > select_gpu', '#!/bin/bash', 'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID', 'exec \$*', 'EOF']
+        self.prerun_cmds += ['chmod +x ./select_gpu']
+        self.executable = f'./select_gpu {self.executable}'  
+
+    @sanity_function
+    def check_cpu_gpu_numa_bind(self):
+        cpu_bind = sn.extractall(r'\(CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+        gpu_bind = sn.extractall(r'\(GCD\S+\/CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+        return sn.assert_eq(cpu_bind, gpu_bind)
+
+@rfm.simple_test
+class Hybrid_GPUBind_Check(AffinityTaskBase):
+
+    # Tests for Slurm CPU binding with mask and GPU binding with a custom mapping 
+    # CPU-centric NUMA ordering
+
+    num_gpus = 8
+    num_gpus_per_node = num_gpus 
+    num_tasks = num_gpus
+    num_threads = num_tasks - 1
+
+    @run_after('init')
+    def set_executable(self):
+        self.executable = 'gpu_check'
+        self.executable_opts = ['-l']
+
+    @run_before('run')
+    def set_cpu_gpu_bind(self):
+        cpu_bind_mask = '0xfe,0xfe00,0xfe0000,0xfe000000,0xfe00000000,0xfe0000000000,0xfe000000000000,0xfe00000000000000'
+        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+        self.job.launcher.options += ['--gpu-bind=map_gpu:4,5,2,3,6,7,0,1']
+
+    @sanity_function
+    def check_cpu_gpu_numa_bind(self):
+        cpu_bind = sn.extractall(r'\(CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+        gpu_bind = sn.extractall(r'\(GCD\S+\/CCD(?P<number>\S+)\)', self.stdout, 'number', int)
+        return sn.assert_eq(cpu_bind, gpu_bind)


### PR DESCRIPTION
Simple test for slurm thread binding using `hybrid_check` tool. Single task per node check. Loosely based on CSCS version.