### PR TITLE
Check building AdaptiveCpp with EasyBuild

### DIFF
--- a/checks/easybuild/eb_adaptive_cpp.py
+++ b/checks/easybuild/eb_adaptive_cpp.py
@@ -15,8 +15,8 @@ class AdaptiveCpp_EBCheck(rfm.RegressionTest):
 
     @run_before('compile')
     def setup_build_system(self):
-        self.build_system.easyconfigs = ['/project/project_462000002/maciszpin/LUMI-EasyBuild-contrib/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-23.10.0-cpeGNU-22.12-rocm-5.2.3.eb']
-        self.build_system.options = ['-f']
+        self.build_system.easyconfigs = ['AdaptiveCpp-23.10.0-cpeGNU-22.12-rocm-5.2.3.eb']
+        self.build_system.options = ['-f --pr-target-account=mszpindler --from-pr 1']
 
     @run_before('run')
     def prepare_run(self):

--- a/checks/easybuild/eb_adaptive_cpp.py
+++ b/checks/easybuild/eb_adaptive_cpp.py
@@ -1,0 +1,27 @@
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class AdaptiveCpp_EBCheck(rfm.RegressionTest):
+    valid_systems = ['lumi:gpu']
+    valid_prog_environs = ['cpeGNU']
+    executable = 'acpp'
+    executable_opts = ['--acpp-version']
+    modules = ['EasyBuild-user']
+    build_system = 'EasyBuild'
+
+    tags = {'lumi-stack'}
+
+    @run_before('compile')
+    def setup_build_system(self):
+        self.build_system.easyconfigs = ['/project/project_462000002/maciszpin/LUMI-EasyBuild-contrib/easybuild/easyconfigs/a/AdaptiveCpp/AdaptiveCpp-23.10.0-cpeGNU-22.12-rocm-5.2.3.eb']
+        self.build_system.options = ['-f']
+
+    @run_before('run')
+    def prepare_run(self):
+        self.modules = self.build_system.generated_modules
+
+    @sanity_function
+    def assert_version(self):
+        return sn.assert_found(r'\s+AdaptiveCpp version: 23.10.0.*', self.stdout)


### PR DESCRIPTION
This test requires `-u cray-python` option for Reframe; Easybuild conflicts with cray-python. 