### PR TITLE
Tags for consistency

### DIFF
--- a/checks/apps/abinit/abinit_check.py
+++ b/checks/apps/abinit/abinit_check.py
@@ -8,9 +8,10 @@ class abinit_check(rfm.RunOnlyRegressionTest):
     maintainers = ['mszpindler']
     prerun_cmds = ['sed -i -e "/nstep/s/2/20/" t01.abi']
     executable_opts = ['t01.abi']
-    variables = {
+    env_vars = {
         'ABI_PSPDIR': '.',
     }
+
 
     @sanity_function
     def assert_simulation_success(self):
@@ -31,3 +32,5 @@ class lumi_abinit_cpu_check(abinit_check):
     reference = {
         'lumi:small': {'time': (10.0, None, 0.5, 's')}, 
     } 
+
+    tags = {'contrib/21.12'}

--- a/checks/apps/amber/amber_check.py
+++ b/checks/apps/amber/amber_check.py
@@ -174,6 +174,8 @@ class lumi_amber_check(amber_nve20_check):
         },
     }
 
+    tags = {'contrib/22.08'}
+
     @run_after('init')
     def scope_systems(self):
         valid_systems = {

--- a/checks/apps/cp2k/cp2k_check.py
+++ b/checks/apps/cp2k/cp2k_check.py
@@ -42,3 +42,4 @@ class lumi_cp2k_cpu_check(cp2k_check):
     num_tasks = 256
     num_tasks_per_node = 128
 
+    tags = {'contrib/22.08', 'contrib/22.12'}

--- a/checks/apps/deeplearning/deepspeed/check_deepspeed_bert.py
+++ b/checks/apps/deeplearning/deepspeed/check_deepspeed_bert.py
@@ -17,13 +17,12 @@ class bert_fetch_data_tokenizer(rfm.RunOnlyRegressionTest):
     '''Fixture for fetching the the dataset and tokenizer'''
     local = True
     modules = ['DeepSpeed']
-    variables = {'HF_HOME': './huggingface_home'}
+    env_vars = {'HF_HOME': './huggingface_home'}
     executable = 'python bert_squad_deepspeed_train.py --download-only'
 
     @sanity_function
     def validate_download(self):
         return sn.assert_eq(self.job.exitcode, 0)
-
 
 class bert_fetch_data_tokenizer_singularity(bert_fetch_data_tokenizer):
     modules = []
@@ -50,7 +49,7 @@ class deepspeed_bert_qa_train_base(rfm.RunOnlyRegressionTest):
         'lumi:gpu': {
             'samples_per_sec': (5579, -0.05, None, 'samples/sec')}
     }
-    variables = {
+    env_vars = {
         'NCCL_DEBUG': 'INFO',
         'NCCL_SOCKET_IFNAME': 'hsn0,hsn1,hsn2,hsn3',
         'NCCL_NET_GDR_LEVEL': '3',
@@ -83,6 +82,8 @@ class deepspeed_bert_qa_train(deepspeed_bert_qa_train_base):
     modules = ['DeepSpeed']
     bert_cache = fixture(bert_fetch_data_tokenizer, scope='session')
 
+    tags = {'singularity', 'contrib/22.08'}
+
     @run_before('run')
     def prepare_job(self):
         bert_cache_dir = os.path.join(self.bert_cache.stagedir, 'cache')
@@ -103,6 +104,8 @@ class deepspeed_bert_qa_train_singularity(deepspeed_bert_qa_train_base):
     modules = ['OpenMPI']
     bert_cache = fixture(bert_fetch_data_tokenizer_singularity,
                          scope='session')
+
+    tags = {'singularity', 'contrib/22.06', 'contrib/22.08'}
 
     @run_before('run')
     def set_container_variables(self):

--- a/checks/apps/deeplearning/pytorch/check_pytorch_dist.py
+++ b/checks/apps/deeplearning/pytorch/check_pytorch_dist.py
@@ -11,7 +11,7 @@ class pytorch_distr_cnn_base(rfm.RunOnlyRegressionTest):
     num_tasks = 32
     num_tasks_per_node = 8
     num_gpus_per_node = 8
-    variables = {
+    env_vars = {
         'NCCL_DEBUG': 'INFO',
         'NCCL_SOCKET_IFNAME': 'hsn0,hsn1,hsn2,hsn3',
         'NCCL_NET_GDR_LEVEL': '3',

--- a/checks/apps/gromacs/gromacs_check.py
+++ b/checks/apps/gromacs/gromacs_check.py
@@ -42,6 +42,8 @@ class lumi_gromacs_mpi(gromacs_check):
         },
     }
 
+    tags = {'contrib/22.08', 'contrib/23.09'}
+
     @run_before('run')
     def setup_run(self):
         try:

--- a/checks/apps/nek5000/nek5000_check.py
+++ b/checks/apps/nek5000/nek5000_check.py
@@ -5,13 +5,15 @@ import reframe.utility.sanity as sn
 class nek5000_check(rfm.RegressionTest):
     valid_systems = ['lumi:small']
     valid_prog_environs = ['cpeGNU']
-    modules = ['partition/C', 'Nek5000']
+    modules = ['Nek5000']
     executable = './nek5000'
     strict_check = False
     descr = f'Nek500 test'
     maintainers = ['']
     build_system = 'CustomBuild'
     num_tasks = 32
+
+    tags = {'contrib/21.12'}
 
     @run_before('compile')
     def build_test(self):

--- a/checks/apps/python/check_mpi4py.py
+++ b/checks/apps/python/check_mpi4py.py
@@ -12,6 +12,8 @@ class mpi4py_osu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
     num_tasks = 2
     executable = 'python'
 
+    tags = {'production', 'python', 'craype', 'contrib/22.08', 'contrib/22.12'}
+
     @run_after('init')
     def setup_test(self):
         if self.device_type == 'gpu':
@@ -29,8 +31,6 @@ class mpi4py_osu_pt2pt_bw_base(rfm.RunOnlyRegressionTest):
             self.modules = ['cray-python']
             self.executable_opts = ['osu_bw.py']
    
-    tags = {'python', 'lumi-stack'}
-
     @sanity_function
     def assert_found_max_bandwidth(self):
         max_bandwidth = r'4194304'

--- a/checks/apps/quantumespresso/quantumespresso_check.py
+++ b/checks/apps/quantumespresso/quantumespresso_check.py
@@ -39,3 +39,5 @@ class lumi_quantumespresso_cpu_check(quantumespresso_check):
     reference = {
         'lumi:small': {'time': (110.0, None, 0.05, 's')},
     } 
+
+    tags = {'contrib/22.08', 'contrib/22.12'}

--- a/checks/containers/check-singularity-mpi-module.py
+++ b/checks/containers/check-singularity-mpi-module.py
@@ -35,6 +35,8 @@ class singularity_cray_mpich_bindings_test(rfm.RunOnlyRegressionTest):
 class test_glibc_mount(singularity_cray_mpich_bindings_test):
     modules = ['singularity-bindings']
 
+    tags = {'singularity', 'contrib/22.08'}
+
     @run_before('run')
     def set_container_variables(self):
         self.container_platform.image = 'osu-debian-jessie.sif'
@@ -45,6 +47,8 @@ class test_glibc_mount(singularity_cray_mpich_bindings_test):
 class test_no_glibc_mount(singularity_cray_mpich_bindings_test):
     pe_version = cray_cdt_version()
     modules = [f'singularity-bindings/system-cpeGNU-{pe_version}-noglibc']
+
+    tags = {'singularity', 'contrib/22.08'}
 
     @run_before('run')
     def set_container_variables(self):

--- a/checks/containers/check-singularity-rocm-image.py
+++ b/checks/containers/check-singularity-rocm-image.py
@@ -9,6 +9,8 @@ class singularity_rocm_image(rfm.RunOnlyRegressionTest):
     num_tasks_per_node = 1
     num_gpus_per_node = 8
 
+    tags = {'production', 'singularity', 'craype'}
+
     @sanity_function
     def assert_gpus_found(self):
         num_gpus = sn.count(sn.findall(r'\s+Name\:\s+gfx90a', self.stdout))

--- a/checks/containers/gromacs_amd_container.py
+++ b/checks/containers/gromacs_amd_container.py
@@ -29,6 +29,8 @@ class lumi_gromacs_infinityhub_container(gromacs_check):
         },
     }
 
+    tags = {'production', 'singularity'}
+
     @deferrable
     def energy_benchpep(self):
         return sn.extractsingle(r'\s+Total Energy\s+Conserved En\.\s+Temperature\s+Pressure \(bar\)\s+Constr\. rmsd\n'

--- a/checks/libs/rccl/check_rccl-tests-sing.py
+++ b/checks/libs/rccl/check_rccl-tests-sing.py
@@ -190,9 +190,11 @@ class rccl_tests_allreduce(rccl_test_base):
         }
     }
 
+    tags = {'singularity', 'contrib/22.06', 'contrib/22.08'}
+
     @run_after('init')
     def set_variables(self):
-        self.variables = {
+        self.env_vars = {
             'NCCL_DEBUG': 'INFO',
             'NCCL_SOCKET_IFNAME': 'hsn0,hsn1,hsn2,hsn3',
             'NCCL_NET_GDR_LEVEL': '3',

--- a/checks/microbenchmarks/gpu/comm_scope.py
+++ b/checks/microbenchmarks/gpu/comm_scope.py
@@ -6,9 +6,9 @@ import reframe.utility.sanity as sn
 @rfm.simple_test
 class comm_scope(rfm.RegressionTest):
     valid_systems = ['lumi:gpu']
-    valid_prog_environs = ['builtin-hip']
+    valid_prog_environs = ['builtin']
     sourcesdir = 'https://github.com/c3sr/comm_scope -b v0.12.0'
-    modules = ['buildtools']
+    modules = ['buildtools', 'rocm']
     build_system = 'CMake'
     executable = './build/comm_scope'
     executable_opts = ['--benchmark_filter="Comm_implicit_managed_GPUWrGPU_fine/0/([1-7])/log2\(N\):30/"', '--benchmark_out_format=json', '--benchmark_out=rfm_job.json']
@@ -25,13 +25,15 @@ class comm_scope(rfm.RegressionTest):
         }
     }
 
+    tags = {'production', 'craype'}
+
     @run_after('setup')
     def setup_compile(self):
         self.build_job.num_cpus_per_task = 64
 
     @run_before('run')
     def set_env_vars(self):
-        self.variables = {
+        self.env_vars = {
             'LD_LIBRARY_PATH': '$LD_LIBRARY_PATH:/opt/rocm/llvm/lib/',
         }
 

--- a/checks/microbenchmarks/mpi/osu_check.py
+++ b/checks/microbenchmarks/mpi/osu_check.py
@@ -40,7 +40,7 @@ class lumi_osu_benchmarks(osu_build_run):
     use_multithreading = False
     exclusive_access = True
     time_limit = '10m'
-    tags = {'production', 'benchmark',}
+    tags = {'production', 'craype'}
     maintainers = ['@rsarm', '@mszpindler']
 
     @run_after('init')

--- a/checks/prgenv/hip/hipInfo.py
+++ b/checks/prgenv/hip/hipInfo.py
@@ -13,6 +13,8 @@ class HipInfo(rfm.RegressionTest):
     maintainers = ['mszpindler']
     num_gpus_per_node = 8
 
+    tags = {'production', 'craype'}
+
     @sanity_function
     def validate_solution(self):
         num_devices = sn.count(sn.findall(r'^device#', self.stdout))

--- a/checks/prgenv/openmp/openmp_gpu_offload.py
+++ b/checks/prgenv/openmp/openmp_gpu_offload.py
@@ -6,7 +6,7 @@ import reframe.utility.sanity as sn
 class vAdd_ompGPU(rfm.RegressionTest):
     descr = 'Checks OpenMP target offload on GPU'
     valid_systems = ['lumi:gpu']
-    valid_prog_environs = ['PrgEnv-amd', 'builtin-hip']
+    valid_prog_environs = ['PrgEnv-cray', 'PrgEnv-amd', 'builtin-hip']
     num_gpus_per_node = 1
     build_system = 'Make'
     sourcesdir = 'https://code.ornl.gov/olcf/vector_addition.git'

--- a/checks/slurm/affinity_check.py
+++ b/checks/slurm/affinity_check.py
@@ -15,7 +15,7 @@ class AffinityTaskBase(rfm.RunOnlyRegressionTest):
     valid_systems = ['lumi:gpu', 'lumi:small']
     valid_prog_environs = ['builtin']
     maintainers = ['mszpindler']
-    tags = {'production'}
+    tags = {'production', 'lumi'}
 
     exclusive_access= True
     modules = ['lumi-CPEtools']

--- a/checks/slurm/het_job.py
+++ b/checks/slurm/het_job.py
@@ -15,7 +15,8 @@ class HeterogeneousJob(rfm.RunOnlyRegressionTest):
     valid_prog_environs = ['builtin']
     maintainers = ['mszpindler']
     modules = ['lumi-CPEtools']
-    tags = {'production'}
+
+    tags = {'production', 'lumi'}
 
     exclusive_access= True
     time_limit = 180

--- a/checks/slurm/multi_launch.py
+++ b/checks/slurm/multi_launch.py
@@ -11,6 +11,8 @@ class MultiLaunchTest(rfm.RunOnlyRegressionTest):
     num_nodes = 3
     num_tasks = num_nodes*num_tasks_per_node
 
+    tags = {'production', 'lumi'}
+
     @run_before('run')
     def pre_launch(self):
         cmd = self.job.launcher.run_command(self.job)

--- a/config/lumi.py
+++ b/config/lumi.py
@@ -7,6 +7,7 @@ site_configuration = {
             'descr': 'LUMI Cray EX Supercomputer',
             'hostnames': ['ln\d+-nmn', 'uan\d+-nmn.local', '\S+'],
             'modules_system': 'lmod',
+            'modules': ['LUMI'],
             'resourcesdir': '/projappl/%s/reframe_resources/' % project,
             'partitions': [
                 {
@@ -22,7 +23,7 @@ site_configuration = {
                     ],
                     'descr': 'Login nodes',
                     'max_jobs': 4,
-                    'modules': ['LUMI', 'partition/L'],
+                    'modules': ['partition/L'],
                     'launcher': 'local'
                 },
                 {
@@ -46,7 +47,7 @@ site_configuration = {
                         'cpeGNU',
                     ],
                     'max_jobs': 100,
-                    'modules': ['LUMI', 'partition/C'],
+                    'modules': ['partition/C'],
                     'access': ['--partition small',
                                f'--account={project}'],
                     'resources': [
@@ -78,7 +79,7 @@ site_configuration = {
                         'cpeGNU',
                     ],
                     'max_jobs': 100,
-                    'modules': ['LUMI', 'partition/C'],
+                    'modules': ['partition/C'],
                     'access': ['--partition standard',
                                f'--account={project}'],
                     'resources': [
@@ -111,7 +112,7 @@ site_configuration = {
                         'cpeGNU',
                     ],
                     'max_jobs': 10,
-                    'modules': ['LUMI', 'partition/G'],
+                    'modules': ['partition/G'],
                     'access': ['--partition small-g',
                                f'--account={project}'],
                     'resources': [


### PR DESCRIPTION
Intoduces tags: `craype`, `lumi`, `contrib/x.y`, `singularity`, `python`. The idea behind is to keep consistency with the software stack versions.