### PR TITLE
Refine GPU binding options for srun

### DIFF
--- a/checks/apps/cp2k/cp2k_check.py
+++ b/checks/apps/cp2k/cp2k_check.py
@@ -81,26 +81,6 @@ class lumi_cp2k_gpu_check(cp2k_check):
 
     executable = 'cp2k.psmp'
     executable_opts = ['H2O-256.inp']
-
-    # We have to use the script here becuase we have to make sure that every
-    #  rank has exactly one GPU. It would be nice to use the `--gpus-per-task`
-    #  flag but that does not seem to work.
-    @run_after('init')
-    def add_select_gpu_wrapper(self):
-        self.prerun_cmds += [
-            'cat << EOF > select_gpu',
-            '#!/bin/bash',
-            'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-            'exec \$*',
-            'EOF',
-            'chmod +x ./select_gpu'
-        ]
-        self.executable = './select_gpu ' + self.executable
-    
-    @run_before('run')
-    def set_cpu_binding_mask(self):
-        self.job.launcher.options = ["--cpu-bind=mask_cpu:7e000000000000,7e00000000000000,7e0000,7e000000,7e,7e00,7e00000000,7e0000000000"]
-
     prerun_cmds = ["ulimit -s unlimited"]
     env_vars = {
         "MPICH_OFI_NIC_POLICY": "GPU",
@@ -110,3 +90,12 @@ class lumi_cp2k_gpu_check(cp2k_check):
         "OMP_NUM_THREADS": "${SLURM_CPUS_PER_TASK}",
         "OMP_STACKSIZE": "512M",
     }
+
+    @run_before('run')
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            '--cpus-per-task=7',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
+        ]
+

--- a/checks/apps/gromacs/gromacs_benchpep-h.py
+++ b/checks/apps/gromacs/gromacs_benchpep-h.py
@@ -103,21 +103,12 @@ class lumi_gromacs_pep_h(rfm.RunOnlyRegressionTest):
         }
 
     @run_before('run')
-    def set_cpu_mask(self):
-        cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
-
-    @run_after('init')
-    def add_select_gpu_wrapper(self):
-        self.prerun_cmds += [
-            'cat << EOF > select_gpu',
-            '#!/bin/bash',
-            'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-            'exec \$*',
-            'EOF',
-            'chmod +x ./select_gpu'
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            '--cpus-per-task=7',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
         ]
-        self.executable = './select_gpu ' + self.executable
 
     @performance_function('ns/day')
     def perf(self):

--- a/checks/apps/gromacs/gromacs_large.py
+++ b/checks/apps/gromacs/gromacs_large.py
@@ -93,21 +93,12 @@ class lumi_gromacs_large(rfm.RunOnlyRegressionTest):
         }
 
     @run_before('run')
-    def set_cpu_mask(self):
-        cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
-
-    @run_after('init')
-    def add_select_gpu_wrapper(self):
-        self.prerun_cmds += [
-            'cat << EOF > select_gpu',
-            '#!/bin/bash',
-            'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-            'exec \$*',
-            'EOF',
-            'chmod +x ./select_gpu'
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            '--cpus-per-task=7',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
         ]
-        self.executable = './select_gpu ' + self.executable
 
     @performance_function('ns/day')
     def perf(self):

--- a/checks/apps/gromacs/gromacs_stmv.py
+++ b/checks/apps/gromacs/gromacs_stmv.py
@@ -104,21 +104,12 @@ class lumi_gromacs_stmv(rfm.RunOnlyRegressionTest):
         }
 
     @run_before('run')
-    def set_cpu_mask(self):
-        cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
-
-    @run_after('init')
-    def add_select_gpu_wrapper(self):
-        self.prerun_cmds += [
-            'cat << EOF > select_gpu',
-            '#!/bin/bash',
-            'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-            'exec \$*',
-            'EOF',
-            'chmod +x ./select_gpu'
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            '--cpus-per-task=7',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
         ]
-        self.executable = './select_gpu ' + self.executable
 
     @performance_function('ns/day')
     def perf(self):

--- a/checks/apps/namd/namd_stmv.py
+++ b/checks/apps/namd/namd_stmv.py
@@ -64,28 +64,10 @@ class lumi_namd_stmv(rfm.RunOnlyRegressionTest):
             self.num_cpus_per_task = 56
             self.num_tasks = 1
         elif self.gpu_mode == 'offload':
-            #self.executable_opts = ['+ignoresharing', '+devices 0', '+p 6', 'stmv_gpuoff_npt.namd']
             self.executable_opts = ['+p6', '+devices 4,5,2,3,6,7,0,1', 'stmv_gpuoff_npt.namd']
             self.num_cpus_per_task = 7
             self.num_tasks_per_node = 8
             self.num_tasks = self.num_nodes*self.num_tasks_per_node
-
-    #@run_before('run')
-    #def set_cpu_mask(self):
-    #    cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-    #    self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
-
-    #@run_before('run')
-    #def add_select_gpu_wrapper(self):
-    #    self.prerun_cmds += [
-    #        'cat << EOF > select_gpu',
-    #        '#!/bin/bash',
-    #        'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-    #        'exec \$*',
-    #        'EOF',
-    #        'chmod +x ./select_gpu'
-    #    ]
-    #    self.executable = './select_gpu ' + self.executable
 
     @sanity_function
     def validate_energy(self):

--- a/checks/apps/neko/neko_bench.py
+++ b/checks/apps/neko/neko_bench.py
@@ -54,10 +54,6 @@ class NekoTGVBase(rfm.RunOnlyRegressionTest):
     
     mesh_file = variable(str, value='')
 
-    # Set dofs to enable workrate perf var
-    dofs = variable(int, value=0)
-    first_workrate_timestep = variable(int, value=0)
-
     perf_relative = variable(float, value=0.0, loggable=True)
 
     @run_before('compile')
@@ -81,10 +77,6 @@ class NekoTGVBase(rfm.RunOnlyRegressionTest):
         }
 
     @run_before('run')
-    def set_dofs(self):
-        self.dofs = 8**3 * self.size
-
-    @run_before('run')
     def add_executable(self):
         self.executable = os.path.join(self.makeneko.stagedir,
                                        'neko')
@@ -94,27 +86,17 @@ class NekoTGVBase(rfm.RunOnlyRegressionTest):
         self.executable_opts.append(case_file)
 
     @run_before('run')
-    def add_select_gpu_wrapper(self):
-        self.prerun_cmds += [
-            'cat << EOF > select_gpu',
-            '#!/bin/bash',
-            'export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID',
-            'exec \$*',
-            'EOF',
-            'chmod +x ./select_gpu'
-        ]
-        self.executable = './select_gpu ' + self.executable
-
-
-    @run_before('run')
     def set_num_tasks(self):
         self.num_tasks_per_node = self.num_gpus_per_node
         self.num_tasks = self.num_nodes*self.num_tasks_per_node
 
     @run_before('run')
-    def set_cpu_binding(self):
-        cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            '--cpus-per-task=7',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
+        ]
 
     @sanity_function
     def normal_end(self):
@@ -129,8 +111,6 @@ class NekoTGVBase(rfm.RunOnlyRegressionTest):
 
 @rfm.simple_test
 class lumi_neko_bench(NekoTGVBase):
-    first_workrate_timestep = 1200
-
     allref = {
         32768: {
             1: {

--- a/checks/prgenv/hip/hipBandwidth.py
+++ b/checks/prgenv/hip/hipBandwidth.py
@@ -21,14 +21,11 @@ class HipBandwidth(rfm.RegressionTest):
 
     @run_after('init')
     def add_select_gpu_wrapper(self):
-        if self.binding == 'closest':
-            wrapper = 'gpu-affinity-localid.sh'
-        elif self.binding == 'optimal':
+        if self.binding == 'optimal':
             wrapper = 'gpu-affinity.sh'
-        wrapper_path = os.path.join(self.current_system.resourcesdir, 'reframe_resources', 'gpu_wrappers', wrapper)
-        self.prerun_cmds += [f'ln -s {wrapper_path} ./select_gpu.sh']
+            wrapper_path = os.path.join(self.current_system.resourcesdir, 'reframe_resources', 'gpu_wrappers', wrapper)
+            self.prerun_cmds += [f'ln -s {wrapper_path} ./select_gpu.sh']
         
-
     @run_before('compile')
     def pre_compile(self):
         self.prebuild_cmds = ['cd HIP-Basic/bandwidth/']
@@ -36,10 +33,14 @@ class HipBandwidth(rfm.RegressionTest):
 
     @run_before('run')
     def set_exec(self):
-        self.executable = './select_gpu.sh ./HIP-Basic/bandwidth/hip_bandwidth'
+        self.executable = './HIP-Basic/bandwidth/hip_bandwidth'
+        if self.binding == 'optimal':
+            self.executable = './select_gpu.sh ' + self.executable
         if self.binding == 'closest':
-            cpu_bind_mask = '0xfe000000000000,0xfe00000000000000,0xfe0000,0xfe000000,0xfe,0xfe00,0xfe00000000,0xfe0000000000'
-            self.job.launcher.options += [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+            self.job.launcher.options = [
+                '--gpu-bind=map:4,5,2,3,6,7,0,1',
+                '--gres-flags=allow-task-sharing'
+            ]
         self.executable_opts = ['-memory pinned -trials 100 -memcpy htod -start 1073741824 -end 1077936128']   
         self.job.launcher.options += ['--cpu-bind=verbose', '--cpus-per-task=7']
 

--- a/checks/slurm/affinity_check.py
+++ b/checks/slurm/affinity_check.py
@@ -170,7 +170,6 @@ class Hybrid_GPUBind_Check(AffinityTaskBase):
     num_gpus = 8
     num_gpus_per_node = num_gpus 
     num_tasks = num_gpus
-    num_threads = num_tasks - 1
     valid_systems = ['lumi:gpu']
 
     @run_after('init')
@@ -179,10 +178,26 @@ class Hybrid_GPUBind_Check(AffinityTaskBase):
         self.executable_opts = ['-l']
 
     @run_before('run')
-    def set_cpu_gpu_bind(self):
-        cpu_bind_mask = '0xfe,0xfe00,0xfe0000,0xfe000000,0xfe00000000,0xfe0000000000,0xfe000000000000,0xfe00000000000000'
-        self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
-        self.job.launcher.options += ['--gpu-bind=map_gpu:0,1,2,3,4,5,6,7']
+    def set_cpus_per_task(self):
+        self.num_threads = self.num_tasks - 1
+        if self.multithread:
+           self.num_threads = 2*self.num_threads
+
+    #@run_before('run')
+    #def set_cpu_gpu_bind(self):
+    #    cpu_bind_mask = '0xfe,0xfe00,0xfe0000,0xfe000000,0xfe00000000,0xfe0000000000,0xfe000000000000,0xfe00000000000000'
+    #    self.job.launcher.options = [f'--cpu-bind=mask_cpu:{cpu_bind_mask}']
+    #    self.job.launcher.options += ['--gpu-bind=map_gpu:0,1,2,3,4,5,6,7']
+    #
+    # Starting from Slurm v24.05.8 (installed with Jan2026 maintenance) one can use gpu-binding alone
+    # with `--gres-flags=allow-task-sharing` for GPU IPC enabled
+    @run_before('run')
+    def set_gpu_binding(self):
+        self.job.launcher.options = [
+            f'--cpus-per-task={self.num_threads}',
+            '--gpu-bind=map:4,5,2,3,6,7,0,1',
+            '--gres-flags=allow-task-sharing'
+        ]
 
     @sanity_function
     def check_cpu_gpu_numa_bind(self):


### PR DESCRIPTION
Replace cpu bind masks combined with select gpu wrapper for optimal GPU binding with:
* `--gpu-bind=map:4,5,2,3,6,7,0,1`: for a proper task to gpu assingnement (eliminates select wrapper)
* `--gres-flags=allow-task-sharing`: for gpu ipc to be possible between tasks
* `--cpus-per-task=7`: to allocate 7 cores per task/gpu device